### PR TITLE
Upgrades to Freestyle 0.4.1 and frees-rpc 0.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = new {
-  lazy val frees    = "0.4.0"
-  lazy val freesRPC = "0.0.8"
+  lazy val frees    = "0.4.1"
+  lazy val freesRPC = "0.1.2"
   lazy val circe    = "0.9.0-M1"
   lazy val monix    = "3.0.0-M1"
 }
@@ -18,13 +18,8 @@ lazy val `demo-routeguide` = project
       Resolver.bintrayRepo("beyondthelines", "maven")
     ),
     libraryDependencies ++= Seq(
-      "io.frees" %% "frees-core"              % V.frees,
-      "io.frees" %% "frees-async"             % V.frees,
-      "io.frees" %% "frees-async-cats-effect" % V.frees,
-      "io.frees" %% "frees-config"            % V.frees,
-      "io.frees" %% "frees-logging"           % V.frees,
       "io.frees" %% "frees-rpc"               % V.freesRPC,
-      "io.monix" %% "monix"                   % V.monix
+      "io.frees" %% "frees-async-cats-effect" % V.frees,
     ) ++ Seq(
       "io.circe" %% "circe-core",
       "io.circe" %% "circe-generic",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.2
+sbt.version = 1.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.10")
+addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.13")

--- a/routeguide/src/main/scala-future/runtime.scala
+++ b/routeguide/src/main/scala-future/runtime.scala
@@ -20,6 +20,7 @@ import cats.implicits._
 import freestyle._
 import freestyle.implicits._
 import freestyle.async.implicits._
+import freestyle.rpc.client.implicits._
 import routeguide.handlers.RouteGuideClientHandler
 import routeguide.protocols.RouteGuideService
 

--- a/routeguide/src/main/scala-task/runtime.scala
+++ b/routeguide/src/main/scala-task/runtime.scala
@@ -20,6 +20,7 @@ import cats.implicits._
 import freestyle._
 import freestyle.implicits._
 import freestyle.async.implicits._
+import freestyle.rpc.client.implicits._
 import freestyle.asyncCatsEffect.implicits._
 import routeguide.handlers.RouteGuideClientHandler
 import routeguide.protocols.RouteGuideService

--- a/routeguide/src/main/scala/runtime/RouteGuide.scala
+++ b/routeguide/src/main/scala/runtime/RouteGuide.scala
@@ -17,21 +17,16 @@
 package routeguide
 package runtime
 
-import cats.{~>, Comonad}
+import cats.~>
 import cats.implicits._
 import freestyle.async.implicits._
 import freestyle.rpc.server._
-import journal.Logger
-import monix.eval.Task
 import routeguide.handlers.RouteGuideServiceHandler
 import routeguide.protocols.RouteGuideService
 
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 trait RouteGuideEC {
-
-  val logger: Logger = Logger[this.type]
 
   implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
   implicit val S: monix.execution.Scheduler =
@@ -39,41 +34,7 @@ trait RouteGuideEC {
 
 }
 
-trait FutureInstances extends freestyle.rpc.client.FutureInstances {
-
-  protected val atMostDuration: FiniteDuration = 10.seconds
-
-  implicit def futureComonad(implicit ec: ExecutionContext): Comonad[Future] =
-    new Comonad[Future] {
-      def extract[A](x: Future[A]): A = {
-        logger.info(s"${Thread.currentThread().getName} Waiting $atMostDuration for $x...")
-        Await.result(x, atMostDuration)
-      }
-
-      override def coflatMap[A, B](fa: Future[A])(f: (Future[A]) => B): Future[B] = Future(f(fa))
-
-      override def map[A, B](fa: Future[A])(f: (A) => B): Future[B] =
-        fa.map(f)
-    }
-
-  implicit val future2Task: Future ~> Task =
-    new (Future ~> Task) {
-      override def apply[A](fa: Future[A]): Task[A] = {
-        logger.info(s"${Thread.currentThread().getName} Deferring Future to Task...")
-        Task.deferFuture(fa)
-      }
-    }
-}
-
-trait TaskInstances {
-
-  implicit val task2Task: Task ~> Task = new (Task ~> Task) {
-    override def apply[A](fa: Task[A]): Task[A] = fa
-  }
-
-}
-
-trait RouteGuide extends RouteGuideEC with FutureInstances with TaskInstances
+trait RouteGuide extends RouteGuideEC
 
 object server {
 


### PR DESCRIPTION
This PR upgrades to the latest version of `Freestyle` and `frees-rpc`, where we can remove certain boilerplate, as we can see.